### PR TITLE
Fix up unload handling after merge

### DIFF
--- a/devtools/client/framework/toolbox-init.js
+++ b/devtools/client/framework/toolbox-init.js
@@ -87,7 +87,7 @@ if (url.search.length > 1) {
       window.removeEventListener("unload", onUnload);
       toolbox.destroy();
     }
-    window.addEventListener("unload", onUnload, true);
+    window.addEventListener("unload", onUnload);
     toolbox.on("destroy", function () {
       window.removeEventListener("unload", onUnload);
     });


### PR DESCRIPTION
This seems to get the toolbox working again for me. @mykmelez, does it work for you as well?

It also seems to work for @ochameau's original case upstream. This actually fixes a bug in some sense, since the removeEventListener calls need to pass the matching capture value anyway.
